### PR TITLE
deadcode: Optimize use of loader package

### DIFF
--- a/deadcode/deadcode_test.go
+++ b/deadcode/deadcode_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestP1(t *testing.T) {
-	objs := doDir("./testdata/p1", false)
+	objs := doDirs([]string{"./testdata/p1"}, false)
 	compare(t, objs, []string{
 		"unused",
 		"g",
@@ -16,7 +16,7 @@ func TestP1(t *testing.T) {
 }
 
 func TestP2(t *testing.T) {
-	objs := doDir("./testdata/p2", false)
+	objs := doDirs([]string{"./testdata/p2"}, false)
 	compare(t, objs, []string{
 		"main",
 		"unused",
@@ -26,7 +26,7 @@ func TestP2(t *testing.T) {
 }
 
 func TestWithTestFiles(t *testing.T) {
-	objs := doDir("./testdata/p3", true)
+	objs := doDirs([]string{"./testdata/p3"}, true)
 	// Only "y" is unused, x is used in tests.
 	compare(t, objs, []string{"y"})
 }


### PR DESCRIPTION
After the change to deadcode to use golang.org/x/tools/go/loader in
01514f0 the performance severly suffered. The runtime went from 0.5s
to over 2min on a codebase that I work on. I believe this was caused
by a bad use of the loader package.

I changed the code to import all packages at one time and only call
Load() once. This got the runtime of deadcode back to where it was.