### PR TITLE
Ignore pseudo-file "C"

### DIFF
--- a/deadcode/deadcode.go
+++ b/deadcode/deadcode.go
@@ -111,7 +111,12 @@ func doPackage(prog *loader.Program, pkg *loader.PackageInfo) []types.Object {
 			continue
 		}
 		obj := global.Lookup(name)
-		if !used[obj] && (pkg.Pkg.Name() == "main" || !ast.IsExported(name)) {
+		filename := filepath.Base(prog.Fset.Position(obj.Pos()).Filename)
+		if !used[obj] &&
+			(pkg.Pkg.Name() == "main" || !ast.IsExported(name)) &&
+			// Ignore IDs defined in file "C". This is a pseudo-file
+			// generated when a package contains a cgo file.
+			filename != "C" {
 			unused = append(unused, obj)
 		}
 	}


### PR DESCRIPTION
deadcode generates these errors when processing a package that contains a
a cgo file.

foo/bar/C:12:6: _Cgo_ptr is unused
foo/bar/C:15:5: _Cgo_always_false is unused
foo/bar/C:17:6: _Cgo_use is unused
foo/bar/C:20:6: _Ctype_void is unused
foo/bar/C:23:6: _cgo_runtime_cgocall is unused
foo/bar/C:29:6: _cgoCheckPointer is unused
foo/bar/C:32:6: _cgoCheckResult is unused
foo/bar/C:46:6: _cgoexp_e632ca01e69c_CGoMain is unused

"C" doesn't actually exist. I believe the loader generates it
dynamically when parsing a cgo file.

This change ignores any unused identifiers defined in "C".